### PR TITLE
fix: allow consistency threshold values below 0.5

### DIFF
--- a/custom_components/automation_suggestions/config_flow.py
+++ b/custom_components/automation_suggestions/config_flow.py
@@ -72,7 +72,7 @@ def get_config_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                 default=defaults.get(CONF_CONSISTENCY_THRESHOLD, DEFAULT_CONSISTENCY_THRESHOLD),
             ): selector.NumberSelector(
                 selector.NumberSelectorConfig(
-                    min=0.5,
+                    min=0.0,
                     max=1.0,
                     step=0.05,
                     mode=selector.NumberSelectorMode.SLIDER,


### PR DESCRIPTION
Fixes #1

The consistency_threshold slider had a minimum value of 0.5, which prevented users from configuring values below 0.5 even though the default is 0.30. Changed the minimum from 0.5 to 0.0 to allow the full valid range.

## Changes
- Modified `config_flow.py` to set min=0.0 for consistency_threshold slider

Generated with [Claude Code](https://claude.ai/code)