### PR TITLE
feat(notifications): Show all suggestions in single notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ A custom Home Assistant integration that analyzes your manual actions from the l
 - **Time-based Suggestions**: Identifies actions performed at consistent times (e.g., turning on lights every evening at 7pm)
 - **Configurable Thresholds**: Adjust sensitivity via options flow to match your preferences
 - **Rich Sensors**: Exposes suggestion count, top suggestions, and last analysis time
-- **On-demand Services**: `analyze_now` to trigger analysis, `dismiss` to hide unwanted suggestions
-- **Persistent Notifications**: Alerts you to high-confidence suggestions (80%+)
+- **On-demand Actions**: `analyze_now` to trigger analysis, `dismiss` to hide unwanted suggestions
+- **Persistent Notifications**: Shows all suggestions after each analysis run - no dev tools needed
 
 ## Installation via HACS
 
@@ -37,9 +37,11 @@ A custom Home Assistant integration that analyzes your manual actions from the l
 
 ### Quick Start
 
-1. **Run your first analysis**: Go to **Developer Tools → Services** and call `automation_suggestions.analyze_now`
-2. **View results**: Go to **Developer Tools → States** and search for `sensor.automation_suggestions_top`
-3. **Check attributes**: Click the sensor to see the `suggestions` attribute with your top 5 suggestions
+1. **Install the integration**: Go to Settings → Devices & Services → Add Integration → "Automation Suggestions"
+2. **Wait for notification**: Analysis runs automatically on install. You'll see a notification with your suggestions.
+3. **Create automations**: Use the suggestions to create automations in Settings → Automations & Scenes
+
+**Want to run analysis again?** Call `automation_suggestions.analyze_now` from Developer Tools → Actions.
 
 ### Entities Created
 
@@ -64,18 +66,18 @@ Each suggestion in `sensor.automation_suggestions_top` attributes includes:
 | `occurrence_count` | `12` | Total times this pattern was detected |
 | `id` | `light_kitchen_turn_on_07_00` | Unique ID (use with dismiss service) |
 
-## Services
+## Actions
 
 ### `automation_suggestions.analyze_now`
 
 Trigger immediate pattern analysis instead of waiting for the scheduled interval.
 
 **Use cases:**
-- After first installation to see initial suggestions
 - After adjusting configuration options
 - To refresh suggestions after dismissing some
+- To re-run analysis before the scheduled interval
 
-**How to call:** Developer Tools → Services → `automation_suggestions.analyze_now` → Call Service
+**How to call:** Developer Tools → Actions → `automation_suggestions.analyze_now` → Call Service
 
 ### `automation_suggestions.dismiss`
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,6 @@
 """Root conftest - minimal to allow different test types."""
 
-# Note: pytest_homeassistant_custom_component is loaded ONLY in integration tests
-# to allow e2e tests to use real Docker sockets.
+pytest_plugins = ["pytest_homeassistant_custom_component"]
+
+# Note: e2e tests use their own pytest.ini with -p no:homeassistant to disable
+# the plugin and allow real Docker sockets.

--- a/custom_components/automation_suggestions/tests/integration/conftest.py
+++ b/custom_components/automation_suggestions/tests/integration/conftest.py
@@ -1,7 +1,5 @@
 """Integration test fixtures using pytest-homeassistant-custom-component."""
 
-pytest_plugins = ["pytest_homeassistant_custom_component"]
-
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -52,7 +50,13 @@ def mock_analyzer(mock_suggestions):
 
 @pytest.fixture
 def mock_suggestions():
-    """Return sample suggestions for tests."""
+    """Return sample suggestions for tests.
+
+    Includes suggestions with varying confidence scores:
+    - suggestion 1: consistency_score=0.85 (high, above 80% threshold)
+    - suggestion 2: consistency_score=0.72 (medium)
+    - suggestion 3: consistency_score=0.65 (low)
+    """
     from custom_components.automation_suggestions.analyzer import Suggestion
 
     return [
@@ -74,7 +78,7 @@ def mock_suggestions():
             suggested_time="22:30",
             time_window_start="22:15",
             time_window_end="22:45",
-            consistency_score=0.78,
+            consistency_score=0.72,
             occurrence_count=10,
             last_occurrence="2026-01-20T22:32:00+00:00",
         ),
@@ -85,7 +89,7 @@ def mock_suggestions():
             suggested_time="08:00",
             time_window_start="07:45",
             time_window_end="08:15",
-            consistency_score=0.72,
+            consistency_score=0.65,
             occurrence_count=8,
             last_occurrence="2026-01-19T08:02:00+00:00",
         ),
@@ -105,7 +109,7 @@ def mock_store():
         "custom_components.automation_suggestions.coordinator.Store"
     ) as mock_store_class:
         mock_store = AsyncMock()
-        mock_store.async_load = AsyncMock(return_value={"dismissed": [], "notified": []})
+        mock_store.async_load = AsyncMock(return_value={"dismissed": []})
         mock_store.async_save = AsyncMock()
         mock_store_class.return_value = mock_store
         yield mock_store

--- a/docs/brainstorms/2026-01-23-ui-notification-summary-brainstorm.md
+++ b/docs/brainstorms/2026-01-23-ui-notification-summary-brainstorm.md
@@ -1,0 +1,82 @@
+# Brainstorm: Display Analysis Results in UI
+
+**Date:** 2026-01-23
+**Status:** Ready for planning
+
+## What We're Building
+
+A user-friendly way to see automation suggestions without using Developer Tools or parsing sensor attributes.
+
+**Core behavior:**
+1. Run analysis automatically on integration install (no manual trigger needed)
+2. After each analysis, send ONE persistent notification with ALL recommendations
+3. Well-formatted, plain English descriptions
+4. Informational only—no action buttons required
+
+## Why This Approach
+
+**User's problem:** Viewing suggestions currently requires navigating to Developer Tools > States, finding the sensor, and reading raw JSON attributes. This is a poor experience.
+
+**Chosen solution:** Persistent notifications because:
+- Zero configuration required—appears automatically in HA's notification bell
+- Plain English, no metadata to parse
+- Already partially implemented (high-confidence suggestions use this)
+- Doesn't disrupt existing dashboards or require users to build custom cards
+
+**Rejected alternatives:**
+- Custom Lovelace card: Requires JavaScript development and user dashboard configuration
+- Dedicated panel: More work, less discoverable for casual users
+- Markdown template cards: Requires users to edit their dashboards
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Delivery method | Persistent notification | Zero config, already familiar to users |
+| Trigger timing | After each analysis + on install | Eliminates "now what?" for new users |
+| Notification count | Single notification | Avoids notification spam |
+| Content | All recommendations inline | Users see everything at a glance |
+| Actions | Informational only | Keep it simple for V1 |
+
+## Example Notification
+
+```
+Automation Suggestions Found
+
+Based on your recent activity, here are some automations you might want to create:
+
+• Turn on Kitchen Light around 7:00 AM
+  85% consistent, seen 12 times
+
+• Lock Front Door around 11:00 PM
+  78% consistent, seen 8 times
+
+• Turn off Living Room TV around midnight
+  72% consistent, seen 6 times
+
+To create these automations, go to Settings > Automations & Scenes.
+```
+
+## Implementation Notes
+
+**Changes needed:**
+
+1. **Trigger analysis on install** (`__init__.py` or `coordinator.py`)
+   - Call `coordinator.async_refresh()` after setup completes
+   - Or schedule initial analysis with short delay
+
+2. **Modify notification logic** (`coordinator.py`)
+   - Currently: Only notifies for 80%+ confidence suggestions, one per suggestion
+   - New: Single notification after each analysis with ALL suggestions formatted
+
+3. **Format suggestions as readable text**
+   - Use `Suggestion.description` field (already has plain English)
+   - Or build custom format: "{action} {friendly_name} around {suggested_time}"
+
+## Open Questions
+
+None—ready to proceed to planning.
+
+## Next Steps
+
+Run `/workflows:plan` to create implementation plan.

--- a/docs/plans/2026-01-23-feat-notification-summary-all-suggestions-plan.md
+++ b/docs/plans/2026-01-23-feat-notification-summary-all-suggestions-plan.md
@@ -1,0 +1,118 @@
+---
+title: "feat: Show all suggestions in notification summary"
+type: feat
+date: 2026-01-23
+brainstorm: docs/brainstorms/2026-01-23-ui-notification-summary-brainstorm.md
+---
+
+# feat: Show all suggestions in notification summary
+
+## Overview
+
+Modify the notification logic so users see ALL suggestions in a single well-formatted persistent notification after each analysis run—not just high-confidence ones.
+
+**Current behavior:** Only suggestions with ≥80% consistency that haven't been notified before trigger a notification.
+
+**Desired behavior:** Every analysis run sends ONE notification showing ALL suggestions, formatted as plain English recommendations.
+
+## Problem Statement
+
+Users must navigate to Developer Tools > States to see suggestions below 80% confidence. This is a poor experience. The brainstorm concluded that a single, comprehensive notification after each analysis is the simplest way to surface results.
+
+## Proposed Solution
+
+Modify `_async_send_notifications()` in `coordinator.py` to:
+1. Include ALL suggestions (remove 80% threshold filter)
+2. Always send notification after analysis (remove "already notified" filter)
+3. Update message format to match brainstorm example
+
+## Technical Approach
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `custom_components/automation_suggestions/coordinator.py` | Modify `_async_send_notifications()` |
+| `custom_components/automation_suggestions/tests/integration/test_coordinator.py` | Update tests for new behavior |
+
+### Implementation Details
+
+#### coordinator.py changes
+
+**Current** (lines 210-214):
+```python
+new_high_confidence = [
+    s
+    for s in suggestions
+    if s.consistency_score >= HIGH_CONFIDENCE_THRESHOLD and s.id not in self._notified
+]
+```
+
+**New:**
+```python
+# Include all suggestions in notification (no confidence filter)
+# Always notify on each analysis run
+```
+
+**Message format change** (lines 228-235):
+
+Current:
+```
+Found {count} {pattern(s)} you might want to automate:
+
+- {suggestion.description}
+
+View all suggestions in the Automation Suggestions sensor.
+```
+
+New (per brainstorm):
+```
+Automation Suggestions Found
+
+Based on your recent activity, here are some automations you might want to create:
+
+• {formatted suggestion 1}
+  {consistency}% consistent, seen {count} times
+
+• {formatted suggestion 2}
+  {consistency}% consistent, seen {count} times
+
+To create these automations, go to Settings > Automations & Scenes.
+```
+
+#### Key decisions
+
+1. **Remove HIGH_CONFIDENCE_THRESHOLD filter** - All suggestions appear
+2. **Remove "already notified" check** - Show fresh summary every run
+3. **Keep notification_id** - Still replaces previous notification (no spam)
+4. **Keep _notified set?** - Can be removed or repurposed (no longer used for filtering)
+
+### Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| No suggestions found | No notification sent (existing early return) |
+| Only dismissed suggestions | No notification (dismissed already filtered in analyzer) |
+| First install with no history | No suggestions = no notification |
+
+## Acceptance Criteria
+
+- [x] After each analysis, ONE persistent notification appears
+- [x] Notification includes ALL suggestions (not filtered by confidence)
+- [x] Notification format matches brainstorm example
+- [x] On fresh install, analysis runs and notification appears (if suggestions exist)
+- [x] No duplicate notifications (same notification_id replaces previous)
+
+### Testing Requirements
+
+- [x] Unit test: `_async_send_notifications` includes all suggestions
+- [x] Unit test: Notification sent even if all suggestions were previously notified
+- [x] Unit test: Message format matches expected output
+- [x] Unit test: No notification when suggestions list is empty
+- [x] Integration test: Full flow from install to notification
+
+## References
+
+- Brainstorm: `docs/brainstorms/2026-01-23-ui-notification-summary-brainstorm.md`
+- Current implementation: `custom_components/automation_suggestions/coordinator.py:198-258`
+- Constant: `HIGH_CONFIDENCE_THRESHOLD = 0.80` in `const.py:19`


### PR DESCRIPTION
## Summary

- Show ALL suggestions in the notification (not just high-confidence 80%+)
- Send notification after EVERY analysis run (not just for new suggestions)
- Analysis runs automatically on install - no dev tools needed
- Cleaner notification format matching the brainstorm design

## Example Notification

```
Automation Suggestions Found

Based on your recent activity, here are some automations you might want to create:

• turn_on Kitchen Light around 07:00
  85% consistent, seen 12 times

• turn_off Living Room around 22:30
  72% consistent, seen 10 times

To create these automations, go to Settings > Automations & Scenes.
```

## Changes

- `coordinator.py`: Removed HIGH_CONFIDENCE_THRESHOLD filter, removed _notified tracking, updated message format
- `conftest.py`: Moved pytest_plugins to root (pytest requirement)
- `test_coordinator.py`: Added 3 new tests for notification behavior

## Testing

- [x] New tests: `test_notification_includes_all_suggestions`, `test_notification_sent_every_analysis`, `test_no_notification_when_no_suggestions`
- [x] All notification-related tests pass
- [x] Linting passes

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)