### PR TITLE
Fix AttributeError in OptionsFlow config_entry assignment

### DIFF
--- a/custom_components/automation_suggestions/config_flow.py
+++ b/custom_components/automation_suggestions/config_flow.py
@@ -92,15 +92,11 @@ class AutomationSuggestionsConfigFlow(ConfigFlow, domain=DOMAIN):
         config_entry: ConfigEntry,
     ) -> AutomationSuggestionsOptionsFlow:
         """Create the options flow."""
-        return AutomationSuggestionsOptionsFlow(config_entry)
+        return AutomationSuggestionsOptionsFlow()
 
 
 class AutomationSuggestionsOptionsFlow(OptionsFlow):
     """Handle options flow for Automation Suggestions."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         """Manage the options."""


### PR DESCRIPTION
## Summary
Fixed an `AttributeError` that occurred when accessing the integration's options/settings page.

## Problem
The `AutomationSuggestionsOptionsFlow` class was manually setting `self.config_entry` in its `__init__` method, which caused the following error:

```
AttributeError: property 'config_entry' of 'AutomationSuggestionsOptionsFlow' object has no setter
```

This error occurs because in current versions of Home Assistant Core, the base `OptionsFlow` class provides `config_entry` as a read-only property that's automatically injected by the flow manager.

## Solution
- Removed the `__init__` method from `AutomationSuggestionsOptionsFlow` class
- Updated `async_get_options_flow()` to instantiate the flow without passing `config_entry` as a parameter
- The `config_entry` property is now automatically available via the base `OptionsFlow` class

## Technical Details
According to the current Home Assistant developer documentation:
- The `config_entry` property is automatically provided by the `OptionsFlow` base class
- Custom `__init__` methods that manually set `self.config_entry` are deprecated
- The framework handles property injection internally, making manual initialization unnecessary

The fix aligns with the recommended implementation pattern where:
1. The flow handler inherits from `OptionsFlow`
2. No custom `__init__` is defined
3. `self.config_entry` is accessed directly in flow methods (like `async_step_init`)

## Testing
After this fix, the options flow will work correctly when users access the integration's settings page through the Home Assistant UI.

## References
- [OptionsFlow Handler Documentation](https://developers.home-assistant.io/docs/config_entries_options_flow_handler/)
- [OptionsFlow Update (Nov 2024)](https://developers.home-assistant.io/blog/2024/11/12/options-flow/)