### PR TITLE
Fix HOMEASSISTANT_URL environment variable not being read

### DIFF
--- a/tools/extract_manual_actions.py
+++ b/tools/extract_manual_actions.py
@@ -33,6 +33,16 @@ def get_ha_token():
     )
 
 
+def get_ha_base_url():
+    """Get Home Assistant base URL from env var or use default."""
+    url = os.environ.get("HOMEASSISTANT_URL")
+    if url:
+        return url.rstrip('/')  # Remove trailing slash if present
+
+    # Return hardcoded default if no env var
+    return "http://192.168.1.217:8123"
+
+
 def get_logbook_entries(base_url, token, start_time, end_time, entity_id=None):
     """Query the Home Assistant logbook API."""
     headers = {
@@ -290,8 +300,8 @@ def main():
     )
     parser.add_argument(
         "--base-url",
-        default="http://192.168.1.217:8123",
-        help="Home Assistant base URL (default: http://192.168.1.217:8123)"
+        default=get_ha_base_url(),
+        help="Home Assistant base URL (env: HOMEASSISTANT_URL, default: http://192.168.1.217:8123)"
     )
     parser.add_argument(
         "--min-occurrences",

--- a/tools/test_extract_manual_actions.py
+++ b/tools/test_extract_manual_actions.py
@@ -22,6 +22,7 @@ from extract_manual_actions import (
     extract_action_from_entry,
     find_automation_candidates,
     format_time_range,
+    get_ha_base_url,
     get_ha_token,
     get_logbook_entries,
     get_time_window,
@@ -842,6 +843,32 @@ class TestGetHaToken:
             get_ha_token()
 
         assert "No Home Assistant token found" in str(excinfo.value)
+
+
+class TestGetHaBaseUrl:
+    """Tests for the get_ha_base_url function."""
+
+    @patch.dict("os.environ", {"HOMEASSISTANT_URL": "http://homeassistant.local:8123"})
+    def test_returns_url_from_env_var(self):
+        """Should return URL from environment variable."""
+        result = get_ha_base_url()
+        assert result == "http://homeassistant.local:8123"
+
+    @patch.dict("os.environ", {"HOMEASSISTANT_URL": "http://192.168.1.100:8123/"})
+    def test_strips_trailing_slash(self):
+        """Should remove trailing slash from URL."""
+        result = get_ha_base_url()
+        assert result == "http://192.168.1.100:8123"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_returns_default_when_no_env_var(self):
+        """Should return hardcoded default when env var not set."""
+        import os
+        if "HOMEASSISTANT_URL" in os.environ:
+            del os.environ["HOMEASSISTANT_URL"]
+
+        result = get_ha_base_url()
+        assert result == "http://192.168.1.217:8123"
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

The README documents that users can set `HOMEASSISTANT_URL` environment variable to configure the script, but the script was completely ignoring this variable. Instead, it always used the hardcoded default value of `http://192.168.1.217:8123`, forcing users to manually pass `--base-url` on every script invocation.

## Root Cause

The `--base-url` argument in argparse was using a hardcoded default instead of checking the environment variable first. While `get_ha_token()` properly reads from environment variables or files, there was no equivalent function for the base URL.

## Solution

This PR adds a `get_ha_base_url()` helper function that:
1. Checks for `HOMEASSISTANT_URL` environment variable
2. Normalizes the URL (removes trailing slashes)
3. Falls back to the hardcoded default if not set

The priority order is now correctly:
1. **CLI flag** `--base-url` (highest priority)
2. **Environment variable** `HOMEASSISTANT_URL`
3. **Hardcoded default** `http://192.168.1.217:8123`

## Changes

- Added `get_ha_base_url()` function following the same pattern as `get_ha_token()`
- Updated argparse to use the helper function as the default value
- Updated help text to document the environment variable
- Added comprehensive test coverage (3 new tests)