### PR TITLE
feat: Stale automation detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,54 @@ For tests requiring auth:
 4. Copy `.storage/` directory to `tests/e2e/initial_test_state/`
 5. Update `TEST_TOKEN` in `conftest.py`
 
+## Visual E2E Tests (CRITICAL QA)
+
+**Visual E2E testing with Chrome MCP is a CRITICAL part of QA.** Unit and integration tests verify logic, but visual tests verify the actual user experience in a real browser against a real Home Assistant instance.
+
+### Why Visual E2E is Critical
+
+- Catches UI rendering issues that mocked tests miss
+- Verifies Lovelace card JavaScript works in real HA environment
+- Tests WebSocket subscriptions with real coordinator updates
+- Validates CSS styling, tab switching, button interactions
+- Screenshots provide evidence that features actually work
+
+### Running Visual E2E Tests
+
+```bash
+# 1. Start the Docker container with custom component
+python tests/e2e/start_visual_test.py
+
+# 2. Use Chrome MCP tools to run visual tests:
+#    - Navigate to the HA URL printed by the script
+#    - Complete onboarding if fresh container
+#    - Configure the integration
+#    - Add the Lovelace card
+#    - Take screenshots and verify UI elements
+```
+
+### Visual Test Specifications
+
+Visual test procedures are documented in:
+- `tests/e2e/visual_test_stale_automations.md` - Stale automation card tests
+
+### Chrome MCP Tools for Visual Testing
+
+Key tools for visual E2E:
+- `mcp__claude-in-chrome__tabs_context_mcp` - Get browser tab context
+- `mcp__claude-in-chrome__navigate` - Navigate to URLs
+- `mcp__claude-in-chrome__computer` (action: screenshot) - Take screenshots
+- `mcp__claude-in-chrome__read_page` - Read DOM/accessibility tree
+- `mcp__claude-in-chrome__computer` (action: left_click) - Click elements
+
+### QA Checklist
+
+Before merging any Lovelace card changes:
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] E2E API tests pass
+- [ ] **Visual E2E tests pass with screenshots** ← CRITICAL
+
 ## Architecture
 
 ### Key Components

--- a/custom_components/automation_suggestions/config_flow.py
+++ b/custom_components/automation_suggestions/config_flow.py
@@ -23,16 +23,20 @@ from .const import (
     CONF_DOMAIN_FILTER_MODE,
     CONF_FILTERED_DOMAINS,
     CONF_FILTERED_USERS,
+    CONF_IGNORE_AUTOMATION_PATTERNS,
     CONF_LOOKBACK_DAYS,
     CONF_MIN_OCCURRENCES,
+    CONF_STALE_THRESHOLD_DAYS,
     CONF_USER_FILTER_MODE,
     DEFAULT_ANALYSIS_INTERVAL,
     DEFAULT_CONSISTENCY_THRESHOLD,
     DEFAULT_DOMAIN_FILTER_MODE,
     DEFAULT_FILTERED_DOMAINS,
     DEFAULT_FILTERED_USERS,
+    DEFAULT_IGNORE_AUTOMATION_PATTERNS,
     DEFAULT_LOOKBACK_DAYS,
     DEFAULT_MIN_OCCURRENCES,
+    DEFAULT_STALE_THRESHOLD_DAYS,
     DEFAULT_USER_FILTER_MODE,
     DOMAIN,
 )
@@ -77,6 +81,18 @@ def get_config_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
                 CONF_FILTERED_DOMAINS,
                 default=",".join(defaults.get(CONF_FILTERED_DOMAINS, DEFAULT_FILTERED_DOMAINS)),
             ): str,
+            vol.Optional(
+                CONF_STALE_THRESHOLD_DAYS,
+                default=defaults.get(CONF_STALE_THRESHOLD_DAYS, DEFAULT_STALE_THRESHOLD_DAYS),
+            ): vol.All(vol.Coerce(int), vol.Range(min=1, max=365)),
+            vol.Optional(
+                CONF_IGNORE_AUTOMATION_PATTERNS,
+                default=",".join(
+                    defaults.get(
+                        CONF_IGNORE_AUTOMATION_PATTERNS, DEFAULT_IGNORE_AUTOMATION_PATTERNS
+                    )
+                ),
+            ): str,
         }
     )
 
@@ -103,6 +119,11 @@ class AutomationSuggestionsConfigFlow(ConfigFlow, domain=DOMAIN):
                 for d in user_input.get(CONF_FILTERED_DOMAINS, "").split(",")
                 if d.strip()
             ]
+            ignore_patterns = [
+                p.strip()
+                for p in user_input.get(CONF_IGNORE_AUTOMATION_PATTERNS, "").split(",")
+                if p.strip()
+            ]
 
             return self.async_create_entry(
                 title="Automation Suggestions",
@@ -119,6 +140,10 @@ class AutomationSuggestionsConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_DOMAIN_FILTER_MODE, DEFAULT_DOMAIN_FILTER_MODE
                     ),
                     CONF_FILTERED_DOMAINS: filtered_domains,
+                    CONF_STALE_THRESHOLD_DAYS: int(
+                        user_input.get(CONF_STALE_THRESHOLD_DAYS, DEFAULT_STALE_THRESHOLD_DAYS)
+                    ),
+                    CONF_IGNORE_AUTOMATION_PATTERNS: ignore_patterns,
                 },
             )
 
@@ -151,6 +176,11 @@ class AutomationSuggestionsOptionsFlow(OptionsFlowWithConfigEntry):
                 for d in user_input.get(CONF_FILTERED_DOMAINS, "").split(",")
                 if d.strip()
             ]
+            ignore_patterns = [
+                p.strip()
+                for p in user_input.get(CONF_IGNORE_AUTOMATION_PATTERNS, "").split(",")
+                if p.strip()
+            ]
 
             return self.async_create_entry(
                 title="",
@@ -167,6 +197,10 @@ class AutomationSuggestionsOptionsFlow(OptionsFlowWithConfigEntry):
                         CONF_DOMAIN_FILTER_MODE, DEFAULT_DOMAIN_FILTER_MODE
                     ),
                     CONF_FILTERED_DOMAINS: filtered_domains,
+                    CONF_STALE_THRESHOLD_DAYS: int(
+                        user_input.get(CONF_STALE_THRESHOLD_DAYS, DEFAULT_STALE_THRESHOLD_DAYS)
+                    ),
+                    CONF_IGNORE_AUTOMATION_PATTERNS: ignore_patterns,
                 },
             )
 

--- a/custom_components/automation_suggestions/const.py
+++ b/custom_components/automation_suggestions/const.py
@@ -11,6 +11,8 @@ CONF_USER_FILTER_MODE = "user_filter_mode"
 CONF_FILTERED_USERS = "filtered_users"
 CONF_DOMAIN_FILTER_MODE = "domain_filter_mode"
 CONF_FILTERED_DOMAINS = "filtered_domains"
+CONF_STALE_THRESHOLD_DAYS = "stale_threshold_days"
+CONF_IGNORE_AUTOMATION_PATTERNS = "ignore_automation_patterns"
 
 # Defaults
 DEFAULT_ANALYSIS_INTERVAL = 7  # days
@@ -22,6 +24,8 @@ DEFAULT_USER_FILTER_MODE = "none"
 DEFAULT_FILTERED_USERS: list[str] = []
 DEFAULT_DOMAIN_FILTER_MODE = "none"
 DEFAULT_FILTERED_DOMAINS: list[str] = []
+DEFAULT_STALE_THRESHOLD_DAYS = 30
+DEFAULT_IGNORE_AUTOMATION_PATTERNS: list[str] = []
 
 # Notification threshold for high-confidence suggestions
 HIGH_CONFIDENCE_THRESHOLD = 0.80

--- a/custom_components/automation_suggestions/coordinator.py
+++ b/custom_components/automation_suggestions/coordinator.py
@@ -19,15 +19,17 @@ from homeassistant.helpers.update_coordinator import (
     UpdateFailed,
 )
 
-from .analyzer import Suggestion, analyze_patterns_async
+from .analyzer import StaleAutomation, Suggestion, analyze_patterns_async, find_stale_automations
 from .const import (
     CONF_ANALYSIS_INTERVAL,
     CONF_CONSISTENCY_THRESHOLD,
     CONF_DOMAIN_FILTER_MODE,
     CONF_FILTERED_DOMAINS,
     CONF_FILTERED_USERS,
+    CONF_IGNORE_AUTOMATION_PATTERNS,
     CONF_LOOKBACK_DAYS,
     CONF_MIN_OCCURRENCES,
+    CONF_STALE_THRESHOLD_DAYS,
     CONF_USER_FILTER_MODE,
     DEFAULT_ANALYSIS_INTERVAL,
     DEFAULT_CONSISTENCY_THRESHOLD,
@@ -35,8 +37,10 @@ from .const import (
     DEFAULT_EMOJI,
     DEFAULT_FILTERED_DOMAINS,
     DEFAULT_FILTERED_USERS,
+    DEFAULT_IGNORE_AUTOMATION_PATTERNS,
     DEFAULT_LOOKBACK_DAYS,
     DEFAULT_MIN_OCCURRENCES,
+    DEFAULT_STALE_THRESHOLD_DAYS,
     DEFAULT_USER_FILTER_MODE,
     DOMAIN,
     DOMAIN_EMOJI_MAP,
@@ -48,7 +52,7 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 # Storage version for schema migrations
-STORAGE_VERSION = 1
+STORAGE_VERSION = 2
 
 
 class AutomationSuggestionsCoordinator(DataUpdateCoordinator[list[Suggestion]]):
@@ -87,6 +91,8 @@ class AutomationSuggestionsCoordinator(DataUpdateCoordinator[list[Suggestion]]):
         # Initialize storage for dismissed suggestions
         self._store: Store[dict[str, Any]] = Store(hass, STORAGE_VERSION, f"{DOMAIN}.persisted")
         self._dismissed: set[str] = set()
+        self._stale_automations: list[StaleAutomation] = []
+        self._dismissed_stale: set[str] = set()
         self._last_update_time: datetime | None = None
 
         # Cache config values
@@ -125,6 +131,16 @@ class AutomationSuggestionsCoordinator(DataUpdateCoordinator[list[Suggestion]]):
             )
         )
 
+        # Cache stale detection config
+        self._stale_threshold_days: int = entry.options.get(
+            CONF_STALE_THRESHOLD_DAYS,
+            entry.data.get(CONF_STALE_THRESHOLD_DAYS, DEFAULT_STALE_THRESHOLD_DAYS),
+        )
+        self._ignore_automation_patterns: list[str] = entry.options.get(
+            CONF_IGNORE_AUTOMATION_PATTERNS,
+            entry.data.get(CONF_IGNORE_AUTOMATION_PATTERNS, DEFAULT_IGNORE_AUTOMATION_PATTERNS),
+        )
+
         _LOGGER.debug(
             "Coordinator initialized with interval=%d days, lookback=%d days, "
             "min_occurrences=%d, consistency=%.2f",
@@ -139,14 +155,20 @@ class AutomationSuggestionsCoordinator(DataUpdateCoordinator[list[Suggestion]]):
         """Return the set of dismissed suggestion IDs."""
         return self._dismissed
 
-    async def async_load_persisted(self) -> None:
-        """Load dismissed suggestions from storage.
+    @property
+    def stale_automations(self) -> list[StaleAutomation]:
+        """Return stale automations excluding dismissed."""
+        return [s for s in self._stale_automations if s.automation_id not in self._dismissed_stale]
 
-        Should be called during integration setup before first refresh.
+    async def async_load_persisted(self) -> None:
+        """Load dismissed suggestions and stale automations from storage.
+
+        Handles migration from storage v1 to v2.
         """
         try:
             stored_data = await self._store.async_load()
             if stored_data:
+                # Load dismissed suggestions
                 if "dismissed" in stored_data:
                     self._dismissed = set(stored_data["dismissed"])
                     _LOGGER.debug(
@@ -155,58 +177,72 @@ class AutomationSuggestionsCoordinator(DataUpdateCoordinator[list[Suggestion]]):
                     )
                 else:
                     self._dismissed = set()
+
+                # Load dismissed stale automations (v2+)
+                if "dismissed_stale" in stored_data:
+                    self._dismissed_stale = set(stored_data["dismissed_stale"])
+                    _LOGGER.debug(
+                        "Loaded %d dismissed stale automations from storage",
+                        len(self._dismissed_stale),
+                    )
+                else:
+                    self._dismissed_stale = set()
             else:
                 self._dismissed = set()
-                _LOGGER.debug("No persisted suggestions found in storage")
+                self._dismissed_stale = set()
+                _LOGGER.debug("No persisted data found in storage")
         except Exception as err:
-            _LOGGER.warning("Error loading persisted suggestions: %s", err)
+            _LOGGER.warning("Error loading persisted data: %s", err)
             self._dismissed = set()
+            self._dismissed_stale = set()
 
-    async def async_dismiss(self, suggestion_id: str) -> None:
-        """Dismiss a suggestion and persist to storage.
+    async def async_dismiss(self, item_id: str) -> None:
+        """Dismiss a suggestion or stale automation and persist to storage.
 
         Args:
-            suggestion_id: The ID of the suggestion to dismiss.
+            item_id: The ID of the item to dismiss. If starts with 'automation.',
+                     treats as stale automation; otherwise treats as suggestion.
         """
-        if suggestion_id in self._dismissed:
-            _LOGGER.debug("Suggestion %s already dismissed", suggestion_id)
-            return
+        if item_id.startswith("automation."):
+            if item_id in self._dismissed_stale:
+                _LOGGER.debug("Stale automation %s already dismissed", item_id)
+                return
+            self._dismissed_stale.add(item_id)
+            _LOGGER.info("Dismissed stale automation: %s", item_id)
+        else:
+            if item_id in self._dismissed:
+                _LOGGER.debug("Suggestion %s already dismissed", item_id)
+                return
+            self._dismissed.add(item_id)
+            _LOGGER.info("Dismissed suggestion: %s", item_id)
 
-        self._dismissed.add(suggestion_id)
-        _LOGGER.info("Dismissed suggestion: %s", suggestion_id)
-
-        # Persist to storage
         await self._async_save_persisted()
-
-        # Trigger an update to refresh the sensor data
-        # (removes the dismissed suggestion from the list)
         await self.async_request_refresh()
 
     async def async_clear_dismissed(self) -> None:
-        """Clear all dismissed suggestions.
-
-        This can be useful for testing or if a user wants to re-evaluate
-        previously dismissed suggestions.
-        """
+        """Clear all dismissed suggestions and stale automations."""
         self._dismissed.clear()
+        self._dismissed_stale.clear()
         await self._async_save_persisted()
-        _LOGGER.info("Cleared all dismissed suggestions")
+        _LOGGER.info("Cleared all dismissed items")
         await self.async_request_refresh()
 
     async def _async_save_persisted(self) -> None:
-        """Save dismissed suggestions to storage."""
+        """Save dismissed suggestions and stale automations to storage."""
         try:
             await self._store.async_save(
                 {
                     "dismissed": list(self._dismissed),
+                    "dismissed_stale": list(self._dismissed_stale),
                 }
             )
             _LOGGER.debug(
-                "Saved %d dismissed suggestions to storage",
+                "Saved %d dismissed suggestions and %d dismissed stale automations",
                 len(self._dismissed),
+                len(self._dismissed_stale),
             )
         except Exception as err:
-            _LOGGER.error("Error saving persisted suggestions: %s", err)
+            _LOGGER.error("Error saving persisted data: %s", err)
 
     async def _async_send_notifications(self, suggestions: list[Suggestion]) -> None:
         """Send a persistent notification with all suggestions grouped by domain.
@@ -327,6 +363,30 @@ class AutomationSuggestionsCoordinator(DataUpdateCoordinator[list[Suggestion]]):
             # Send notification with all suggestions
             await self._async_send_notifications(suggestions)
 
+            # Detect stale automations
+            try:
+                automation_states = [
+                    {
+                        "entity_id": state.entity_id,
+                        "state": state.state,
+                        "attributes": dict(state.attributes),
+                    }
+                    for state in self.hass.states.async_all("automation")
+                ]
+                self._stale_automations = find_stale_automations(
+                    automation_states,
+                    self._stale_threshold_days,
+                    self._ignore_automation_patterns,
+                )
+                _LOGGER.info(
+                    "Found %d stale automations (threshold: %d days)",
+                    len(self._stale_automations),
+                    self._stale_threshold_days,
+                )
+            except Exception as err:
+                _LOGGER.warning("Error detecting stale automations: %s", err)
+                self._stale_automations = []
+
             return suggestions
 
         except Exception as err:
@@ -383,6 +443,16 @@ class AutomationSuggestionsCoordinator(DataUpdateCoordinator[list[Suggestion]]):
             entry.data.get(CONF_ANALYSIS_INTERVAL, DEFAULT_ANALYSIS_INTERVAL),
         )
         self.update_interval = timedelta(days=analysis_interval_days)
+
+        # Update stale detection config
+        self._stale_threshold_days = entry.options.get(
+            CONF_STALE_THRESHOLD_DAYS,
+            entry.data.get(CONF_STALE_THRESHOLD_DAYS, DEFAULT_STALE_THRESHOLD_DAYS),
+        )
+        self._ignore_automation_patterns = entry.options.get(
+            CONF_IGNORE_AUTOMATION_PATTERNS,
+            entry.data.get(CONF_IGNORE_AUTOMATION_PATTERNS, DEFAULT_IGNORE_AUTOMATION_PATTERNS),
+        )
 
         _LOGGER.debug(
             "Coordinator config updated: interval=%d days, lookback=%d days, "

--- a/custom_components/automation_suggestions/coordinator.py
+++ b/custom_components/automation_suggestions/coordinator.py
@@ -373,6 +373,15 @@ class AutomationSuggestionsCoordinator(DataUpdateCoordinator[list[Suggestion]]):
                     }
                     for state in self.hass.states.async_all("automation")
                 ]
+
+                # DEBUG: Log what last_triggered values we see from state machine
+                for auto_state in automation_states:
+                    _LOGGER.debug(
+                        "Coordinator sees automation: entity_id=%s, last_triggered=%r",
+                        auto_state["entity_id"],
+                        auto_state["attributes"].get("last_triggered"),
+                    )
+
                 self._stale_automations = find_stale_automations(
                     automation_states,
                     self._stale_threshold_days,

--- a/custom_components/automation_suggestions/strings.json
+++ b/custom_components/automation_suggestions/strings.json
@@ -12,7 +12,9 @@
           "user_filter_mode": "Filter users",
           "filtered_users": "User IDs to filter",
           "domain_filter_mode": "Filter domains",
-          "filtered_domains": "Domains to filter"
+          "filtered_domains": "Domains to filter",
+          "stale_threshold_days": "Stale automation threshold (days)",
+          "ignore_automation_patterns": "Ignore automation patterns (comma-separated)"
         },
         "data_description": {
           "analysis_interval": "How often to scan your logbook for patterns. Lower values find patterns faster but use more resources.",
@@ -46,7 +48,9 @@
           "user_filter_mode": "Filter users",
           "filtered_users": "User IDs to filter",
           "domain_filter_mode": "Filter domains",
-          "filtered_domains": "Domains to filter"
+          "filtered_domains": "Domains to filter",
+          "stale_threshold_days": "Stale automation threshold (days)",
+          "ignore_automation_patterns": "Ignore automation patterns (comma-separated)"
         },
         "data_description": {
           "analysis_interval": "How often to scan your logbook for patterns. Lower values find patterns faster but use more resources.",
@@ -89,6 +93,9 @@
             "name": "Suggestions found"
           }
         }
+      },
+      "stale_count": {
+        "name": "Stale Automations Count"
       }
     },
     "binary_sensor": {

--- a/custom_components/automation_suggestions/tests/integration/test_services.py
+++ b/custom_components/automation_suggestions/tests/integration/test_services.py
@@ -1,5 +1,7 @@
 """Tests for service handlers."""
 
+from unittest.mock import patch
+
 import pytest
 
 from custom_components.automation_suggestions.const import DOMAIN
@@ -66,3 +68,102 @@ class TestServices:
         """Test service fails gracefully when integration not loaded."""
         # Services shouldn't be registered if integration isn't set up
         assert not hass.services.has_service(DOMAIN, "analyze_now")
+
+    @pytest.mark.asyncio
+    async def test_dismiss_stale_automation(self, hass, config_entry, mock_analyzer, mock_store):
+        """Test dismiss service works with automation.* IDs (stale automations)."""
+        from custom_components.automation_suggestions.analyzer import StaleAutomation
+
+        config_entry.add_to_hass(hass)
+
+        # Mock find_stale_automations to return a stale automation
+        stale_result = [
+            StaleAutomation(
+                automation_id="automation.old_backup",
+                friendly_name="Old Backup Automation",
+                last_triggered="2025-12-01T10:00:00+00:00",
+                days_since_triggered=56,
+                is_disabled=False,
+            ),
+        ]
+
+        with patch(
+            "custom_components.automation_suggestions.coordinator.find_stale_automations",
+            return_value=stale_result,
+        ):
+            await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        # Dismiss the stale automation
+        await hass.services.async_call(
+            DOMAIN,
+            "dismiss",
+            {"suggestion_id": "automation.old_backup"},
+            blocking=True,
+        )
+
+        coordinator = config_entry.runtime_data
+        # Should be in _dismissed_stale, not _dismissed
+        assert "automation.old_backup" in coordinator._dismissed_stale
+        assert "automation.old_backup" not in coordinator.dismissed
+
+    @pytest.mark.asyncio
+    async def test_dismiss_stale_persists(self, hass, config_entry, mock_analyzer, mock_store):
+        """Test dismissed stale automation is persisted to storage."""
+        from custom_components.automation_suggestions.analyzer import StaleAutomation
+
+        config_entry.add_to_hass(hass)
+
+        # Mock find_stale_automations to return a stale automation
+        stale_result = [
+            StaleAutomation(
+                automation_id="automation.old_backup",
+                friendly_name="Old Backup Automation",
+                last_triggered="2025-12-01T10:00:00+00:00",
+                days_since_triggered=56,
+                is_disabled=False,
+            ),
+        ]
+
+        with patch(
+            "custom_components.automation_suggestions.coordinator.find_stale_automations",
+            return_value=stale_result,
+        ):
+            await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+
+        # Dismiss the stale automation
+        await hass.services.async_call(
+            DOMAIN,
+            "dismiss",
+            {"suggestion_id": "automation.old_backup"},
+            blocking=True,
+        )
+
+        # Verify storage was called with both dismissed and dismissed_stale
+        mock_store.async_save.assert_called()
+        save_call_args = mock_store.async_save.call_args[0][0]
+        assert "dismissed_stale" in save_call_args
+        assert "automation.old_backup" in save_call_args["dismissed_stale"]
+
+    @pytest.mark.asyncio
+    async def test_dismiss_regular_suggestion_not_in_dismissed_stale(
+        self, hass, config_entry, mock_analyzer, mock_store
+    ):
+        """Test that regular suggestions go to dismissed, not dismissed_stale."""
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Dismiss a regular suggestion (not starting with automation.)
+        await hass.services.async_call(
+            DOMAIN,
+            "dismiss",
+            {"suggestion_id": "light_kitchen_turn_on_07_00"},
+            blocking=True,
+        )
+
+        coordinator = config_entry.runtime_data
+        # Should be in _dismissed, not _dismissed_stale
+        assert "light_kitchen_turn_on_07_00" in coordinator.dismissed
+        assert "light_kitchen_turn_on_07_00" not in coordinator._dismissed_stale

--- a/custom_components/automation_suggestions/translations/en.json
+++ b/custom_components/automation_suggestions/translations/en.json
@@ -8,7 +8,9 @@
           "analysis_interval": "Analysis interval (days)",
           "lookback_days": "Days of history to analyze",
           "min_occurrences": "Minimum occurrences for pattern",
-          "consistency_threshold": "Consistency threshold (0-1)"
+          "consistency_threshold": "Consistency threshold (0-1)",
+          "stale_threshold_days": "Stale automation threshold (days)",
+          "ignore_automation_patterns": "Ignore automation patterns (comma-separated)"
         }
       }
     },
@@ -27,7 +29,9 @@
           "analysis_interval": "Analysis interval (days)",
           "lookback_days": "Days of history to analyze",
           "min_occurrences": "Minimum occurrences for pattern",
-          "consistency_threshold": "Consistency threshold (0-1)"
+          "consistency_threshold": "Consistency threshold (0-1)",
+          "stale_threshold_days": "Stale automation threshold (days)",
+          "ignore_automation_patterns": "Ignore automation patterns (comma-separated)"
         }
       }
     }
@@ -42,6 +46,9 @@
       },
       "last_analysis": {
         "name": "Last analysis"
+      },
+      "stale_count": {
+        "name": "Stale Automations Count"
       }
     },
     "binary_sensor": {

--- a/custom_components/automation_suggestions/www/automation-suggestions-card.js
+++ b/custom_components/automation_suggestions/www/automation-suggestions-card.js
@@ -196,10 +196,10 @@ class AutomationSuggestionsCard extends HTMLElement {
     return `
       <div class="tabs">
         <button class="tab-btn ${this._activeTab === "suggestions" ? "active" : ""}" data-tab="suggestions">
-          Suggestions (${suggCount})
+          Opportunities (${suggCount})
         </button>
         <button class="tab-btn ${this._activeTab === "stale" ? "active" : ""}" data-tab="stale">
-          Stale (${staleCount})
+          Stale Automations (${staleCount})
         </button>
       </div>
     `;
@@ -366,7 +366,10 @@ class AutomationSuggestionsCard extends HTMLElement {
 
     this.innerHTML = `
       <ha-card>
-        <div class="card-header">Automation Suggestions</div>
+        <div class="card-header">
+          <span class="header-title">Automation Suggestions</span>
+          <span class="header-subtitle">Patterns detected from your usage &amp; automations needing attention</span>
+        </div>
         ${tabsHtml}
         ${contentHtml}
         <div class="card-actions">
@@ -400,12 +403,19 @@ class AutomationSuggestionsCard extends HTMLElement {
       }
       .card-header {
         padding: 16px;
-        font-size: 1.2em;
-        font-weight: 500;
         border-bottom: 1px solid var(--divider-color);
         display: flex;
-        align-items: center;
-        gap: 8px;
+        flex-direction: column;
+        gap: 4px;
+      }
+      .header-title {
+        font-size: 1.2em;
+        font-weight: 500;
+      }
+      .header-subtitle {
+        font-size: 0.75rem;
+        color: var(--secondary-text-color);
+        font-weight: 400;
       }
       .tabs {
         display: flex;

--- a/tests/e2e/initial_test_state/automations.yaml
+++ b/tests/e2e/initial_test_state/automations.yaml
@@ -1,0 +1,9 @@
+- id: "preexisting_test_automation"
+  alias: "Pre-existing Test Automation"
+  trigger:
+    - platform: time
+      at: "00:00:00"
+  action:
+    - service: logger.log
+      data:
+        message: "Pre-existing test automation"

--- a/tests/e2e/initial_test_state/configuration.yaml
+++ b/tests/e2e/initial_test_state/configuration.yaml
@@ -12,5 +12,8 @@ recorder:
 # Enable logbook
 logbook:
 
+# Enable automation integration for E2E tests
+automation: !include automations.yaml
+
 # Demo platform for test entities
 demo:

--- a/tests/e2e/test_stale_automations.py
+++ b/tests/e2e/test_stale_automations.py
@@ -1,0 +1,359 @@
+"""
+E2E tests for stale automation detection WebSocket API.
+
+These tests verify:
+- automation_suggestions/list_stale command with pagination
+- Subscribe command includes stale_automations and stale_total
+- Validation of pagination parameters for list_stale
+"""
+
+import asyncio
+import json
+
+import pytest
+import websockets
+
+pytestmark = [pytest.mark.e2e]
+
+
+class TestWebSocketListStale:
+    """Test the automation_suggestions/list_stale WebSocket command."""
+
+    @pytest.fixture
+    async def authenticated_websocket(self, ha_url, ha_token):
+        """Create an authenticated WebSocket connection."""
+        ws_url = ha_url.replace("http://", "ws://").replace("https://", "wss://")
+        ws_url = f"{ws_url}/api/websocket"
+
+        try:
+            websocket = await websockets.connect(ws_url)
+        except (ConnectionRefusedError, OSError) as e:
+            pytest.skip(f"WebSocket not available: {e}")
+            return
+
+        try:
+            # Wait for auth_required
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+            if data["type"] != "auth_required":
+                await websocket.close()
+                pytest.fail(f"Expected auth_required, got: {data['type']}")
+
+            # Send auth
+            auth_msg = {"type": "auth", "access_token": ha_token}
+            await websocket.send(json.dumps(auth_msg))
+
+            # Wait for auth_ok
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+            if data["type"] != "auth_ok":
+                await websocket.close()
+                pytest.fail(f"Expected auth_ok, got: {data}")
+
+            yield websocket
+        finally:
+            await websocket.close()
+
+    @pytest.mark.asyncio
+    async def test_list_stale_returns_data(self, authenticated_websocket):
+        """Call automation_suggestions/list_stale and verify response format."""
+        websocket = authenticated_websocket
+
+        # Send list_stale command
+        cmd = {
+            "id": 1,
+            "type": "automation_suggestions/list_stale",
+            "page": 1,
+            "page_size": 20,
+        }
+        await websocket.send(json.dumps(cmd))
+
+        # Wait for response
+        try:
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+        except TimeoutError:
+            pytest.fail("Timed out waiting for list_stale response")
+
+        # Verify response structure
+        assert data["id"] == 1, f"Response ID mismatch: {data}"
+        assert data["type"] == "result", f"Expected result type, got: {data['type']}"
+        assert data["success"] is True, f"Command failed: {data}"
+
+        # Verify result structure
+        result = data["result"]
+        assert "stale_automations" in result, f"Missing stale_automations in result: {result}"
+        assert "total" in result, f"Missing total in result: {result}"
+        assert "page" in result, f"Missing page in result: {result}"
+        assert "pages" in result, f"Missing pages in result: {result}"
+        assert "page_size" in result, f"Missing page_size in result: {result}"
+
+        # Verify types
+        assert isinstance(result["stale_automations"], list)
+        assert isinstance(result["total"], int)
+        assert isinstance(result["page"], int)
+        assert isinstance(result["pages"], int)
+        assert isinstance(result["page_size"], int)
+
+    @pytest.mark.asyncio
+    async def test_list_stale_pagination(self, authenticated_websocket):
+        """Test pagination with different page and page_size values."""
+        websocket = authenticated_websocket
+
+        # Test page 1 with small page_size
+        cmd1 = {
+            "id": 1,
+            "type": "automation_suggestions/list_stale",
+            "page": 1,
+            "page_size": 5,
+        }
+        await websocket.send(json.dumps(cmd1))
+
+        message = await asyncio.wait_for(websocket.recv(), timeout=10)
+        data1 = json.loads(message)
+        assert data1["success"] is True
+        result1 = data1["result"]
+        assert result1["page"] == 1
+        assert result1["page_size"] == 5
+        assert len(result1["stale_automations"]) <= 5
+
+        # Test page 2
+        cmd2 = {
+            "id": 2,
+            "type": "automation_suggestions/list_stale",
+            "page": 2,
+            "page_size": 5,
+        }
+        await websocket.send(json.dumps(cmd2))
+
+        message = await asyncio.wait_for(websocket.recv(), timeout=10)
+        data2 = json.loads(message)
+        assert data2["success"] is True
+        result2 = data2["result"]
+        assert result2["page"] == 2
+
+        # Test with larger page_size
+        cmd3 = {
+            "id": 3,
+            "type": "automation_suggestions/list_stale",
+            "page": 1,
+            "page_size": 100,
+        }
+        await websocket.send(json.dumps(cmd3))
+
+        message = await asyncio.wait_for(websocket.recv(), timeout=10)
+        data3 = json.loads(message)
+        assert data3["success"] is True
+        result3 = data3["result"]
+        assert result3["page_size"] == 100
+
+    @pytest.mark.asyncio
+    async def test_list_stale_default_pagination(self, authenticated_websocket):
+        """Test that default pagination values work when not specified."""
+        websocket = authenticated_websocket
+
+        # Send command without explicit pagination
+        cmd = {
+            "id": 1,
+            "type": "automation_suggestions/list_stale",
+        }
+        await websocket.send(json.dumps(cmd))
+
+        message = await asyncio.wait_for(websocket.recv(), timeout=10)
+        data = json.loads(message)
+        assert data["success"] is True
+        result = data["result"]
+
+        # Default values should be applied
+        assert result["page"] == 1
+        assert result["page_size"] == 20
+
+
+class TestWebSocketSubscribeIncludesStale:
+    """Test that subscribe includes stale automations."""
+
+    @pytest.fixture
+    async def authenticated_websocket(self, ha_url, ha_token):
+        """Create an authenticated WebSocket connection."""
+        ws_url = ha_url.replace("http://", "ws://").replace("https://", "wss://")
+        ws_url = f"{ws_url}/api/websocket"
+
+        try:
+            websocket = await websockets.connect(ws_url)
+        except (ConnectionRefusedError, OSError) as e:
+            pytest.skip(f"WebSocket not available: {e}")
+            return
+
+        try:
+            # Wait for auth_required
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+            if data["type"] != "auth_required":
+                await websocket.close()
+                pytest.fail(f"Expected auth_required, got: {data['type']}")
+
+            # Send auth
+            auth_msg = {"type": "auth", "access_token": ha_token}
+            await websocket.send(json.dumps(auth_msg))
+
+            # Wait for auth_ok
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+            if data["type"] != "auth_ok":
+                await websocket.close()
+                pytest.fail(f"Expected auth_ok, got: {data}")
+
+            yield websocket
+        finally:
+            await websocket.close()
+
+    @pytest.mark.asyncio
+    async def test_subscribe_includes_stale_automations(self, authenticated_websocket):
+        """Verify subscribe response includes stale_automations and stale_total."""
+        websocket = authenticated_websocket
+
+        # Send subscribe command
+        cmd = {
+            "id": 1,
+            "type": "automation_suggestions/subscribe",
+        }
+        await websocket.send(json.dumps(cmd))
+
+        # Wait for result (subscription acknowledgment)
+        try:
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+        except TimeoutError:
+            pytest.fail("Timed out waiting for subscribe response")
+
+        # Verify subscription was successful
+        assert data["id"] == 1, f"Response ID mismatch: {data}"
+        assert data["type"] == "result", f"Expected result type, got: {data['type']}"
+        assert data["success"] is True, f"Subscribe command failed: {data}"
+
+        # After successful subscription, we should receive initial event data
+        try:
+            event_message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            event_data = json.loads(event_message)
+        except TimeoutError:
+            # It's acceptable if no event is sent when data is None
+            return
+
+        # Verify event structure if received
+        assert event_data["id"] == 1
+        assert event_data["type"] == "event"
+        event = event_data["event"]
+
+        # Verify suggestions are present
+        assert "suggestions" in event, f"Missing suggestions in event: {event}"
+        assert "total" in event, f"Missing total in event: {event}"
+        assert isinstance(event["suggestions"], list)
+        assert isinstance(event["total"], int)
+
+        # Verify stale automations are present
+        assert "stale_automations" in event, f"Missing stale_automations in event: {event}"
+        assert "stale_total" in event, f"Missing stale_total in event: {event}"
+        assert isinstance(event["stale_automations"], list)
+        assert isinstance(event["stale_total"], int)
+
+
+class TestWebSocketListStaleValidation:
+    """Test validation for automation_suggestions/list_stale command."""
+
+    @pytest.fixture
+    async def authenticated_websocket(self, ha_url, ha_token):
+        """Create an authenticated WebSocket connection."""
+        ws_url = ha_url.replace("http://", "ws://").replace("https://", "wss://")
+        ws_url = f"{ws_url}/api/websocket"
+
+        try:
+            websocket = await websockets.connect(ws_url)
+        except (ConnectionRefusedError, OSError) as e:
+            pytest.skip(f"WebSocket not available: {e}")
+            return
+
+        try:
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+            if data["type"] != "auth_required":
+                await websocket.close()
+                pytest.fail(f"Expected auth_required, got: {data['type']}")
+
+            auth_msg = {"type": "auth", "access_token": ha_token}
+            await websocket.send(json.dumps(auth_msg))
+
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+            if data["type"] != "auth_ok":
+                await websocket.close()
+                pytest.fail(f"Expected auth_ok, got: {data}")
+
+            yield websocket
+        finally:
+            await websocket.close()
+
+    @pytest.mark.asyncio
+    async def test_list_stale_invalid_page_size_rejected(self, authenticated_websocket):
+        """Test that invalid page_size values are rejected for list_stale."""
+        websocket = authenticated_websocket
+
+        # Try page_size of 0 (below minimum)
+        cmd = {
+            "id": 1,
+            "type": "automation_suggestions/list_stale",
+            "page": 1,
+            "page_size": 0,
+        }
+        await websocket.send(json.dumps(cmd))
+
+        message = await asyncio.wait_for(websocket.recv(), timeout=10)
+        data = json.loads(message)
+
+        # Should return error for invalid page_size
+        assert data["id"] == 1
+        if data["type"] == "result":
+            assert data["success"] is False, "Should reject page_size of 0"
+
+    @pytest.mark.asyncio
+    async def test_list_stale_page_size_over_max_rejected(self, authenticated_websocket):
+        """Test that page_size over maximum is rejected for list_stale."""
+        websocket = authenticated_websocket
+
+        # Try page_size over 100 (above maximum)
+        cmd = {
+            "id": 1,
+            "type": "automation_suggestions/list_stale",
+            "page": 1,
+            "page_size": 200,
+        }
+        await websocket.send(json.dumps(cmd))
+
+        message = await asyncio.wait_for(websocket.recv(), timeout=10)
+        data = json.loads(message)
+
+        # Should return error for invalid page_size
+        assert data["id"] == 1
+        if data["type"] == "result":
+            assert data["success"] is False, "Should reject page_size over 100"
+
+    @pytest.mark.asyncio
+    async def test_list_stale_invalid_page_rejected(self, authenticated_websocket):
+        """Test that invalid page values are rejected for list_stale."""
+        websocket = authenticated_websocket
+
+        # Try page of 0 (below minimum)
+        cmd = {
+            "id": 1,
+            "type": "automation_suggestions/list_stale",
+            "page": 0,
+            "page_size": 20,
+        }
+        await websocket.send(json.dumps(cmd))
+
+        message = await asyncio.wait_for(websocket.recv(), timeout=10)
+        data = json.loads(message)
+
+        # Should return error for invalid page
+        assert data["id"] == 1
+        if data["type"] == "result":
+            assert data["success"] is False, "Should reject page of 0"

--- a/tests/e2e/test_stale_automations.py
+++ b/tests/e2e/test_stale_automations.py
@@ -357,3 +357,532 @@ class TestWebSocketListStaleValidation:
         assert data["id"] == 1
         if data["type"] == "result":
             assert data["success"] is False, "Should reject page of 0"
+
+
+class TestStaleAutomationDetectionLogic:
+    """Test that stale detection correctly identifies stale vs non-stale automations."""
+
+    @pytest.fixture
+    async def authenticated_websocket(self, ha_url, ha_token):
+        """Create an authenticated WebSocket connection."""
+        ws_url = ha_url.replace("http://", "ws://").replace("https://", "wss://")
+        ws_url = f"{ws_url}/api/websocket"
+
+        try:
+            websocket = await websockets.connect(ws_url)
+        except (ConnectionRefusedError, OSError) as e:
+            pytest.skip(f"WebSocket not available: {e}")
+            return
+
+        try:
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+            if data["type"] != "auth_required":
+                await websocket.close()
+                pytest.fail(f"Expected auth_required, got: {data['type']}")
+
+            auth_msg = {"type": "auth", "access_token": ha_token}
+            await websocket.send(json.dumps(auth_msg))
+
+            message = await asyncio.wait_for(websocket.recv(), timeout=10)
+            data = json.loads(message)
+            if data["type"] != "auth_ok":
+                await websocket.close()
+                pytest.fail(f"Expected auth_ok, got: {data}")
+
+            yield websocket
+        finally:
+            await websocket.close()
+
+    @pytest.fixture
+    def ha_session(self, ha_url, ha_token):
+        """Create a requests session for REST API calls."""
+        import requests
+
+        session = requests.Session()
+        session.headers["Authorization"] = f"Bearer {ha_token}"
+        session.headers["Content-Type"] = "application/json"
+        session.base_url = ha_url
+        return session
+
+    def _create_automation(self, session, automation_id, friendly_name):
+        """Create a test automation via REST API.
+
+        Args:
+            session: Configured requests session
+            automation_id: The ID part (after 'automation.')
+            friendly_name: Human-readable name
+
+        Returns:
+            Response from the API
+        """
+        # Create automation configuration
+        automation_config = {
+            "alias": friendly_name,
+            "trigger": [
+                {
+                    "platform": "time",
+                    "at": "00:00:00",
+                }
+            ],
+            "action": [
+                {
+                    "service": "logger.log",
+                    "data": {"message": f"Test automation {automation_id} triggered"},
+                }
+            ],
+        }
+
+        url = f"{session.base_url}/api/config/automation/config/{automation_id}"
+        return session.post(url, json=automation_config, timeout=30)
+
+    def _delete_automation(self, session, automation_id):
+        """Delete a test automation via REST API."""
+        url = f"{session.base_url}/api/config/automation/config/{automation_id}"
+        return session.delete(url, timeout=30)
+
+    def _trigger_automation(self, session, entity_id):
+        """Trigger an automation to update its last_triggered timestamp.
+
+        Args:
+            session: Configured requests session
+            entity_id: Full entity ID (e.g., 'automation.test_triggered')
+
+        Returns:
+            Response from the API
+        """
+        url = f"{session.base_url}/api/services/automation/trigger"
+        return session.post(url, json={"entity_id": entity_id}, timeout=30)
+
+    def _trigger_analysis(self, session):
+        """Trigger the analyze_now service to refresh stale automation detection."""
+        url = f"{session.base_url}/api/services/automation_suggestions/analyze_now"
+        return session.post(url, json={}, timeout=30)
+
+    def _get_entity_state(self, session, entity_id):
+        """Get the state of an entity via REST API."""
+        url = f"{session.base_url}/api/states/{entity_id}"
+        return session.get(url, timeout=30)
+
+    def _list_automation_entities(self, session):
+        """List all automation entities from the state machine."""
+        url = f"{session.base_url}/api/states"
+        resp = session.get(url, timeout=30)
+        if resp.status_code == 200:
+            all_states = resp.json()
+            return [state["entity_id"] for state in all_states if state["entity_id"].startswith("automation.")]
+        return []
+
+    def _reload_automations(self, session):
+        """Reload automation domain to pick up new automations."""
+        resp = session.post(
+            f"{session.base_url}/api/services/automation/reload",
+            json={},
+        )
+        return resp
+
+    async def _wait_for_entity(self, session, entity_id, max_retries=20, delay=0.5):
+        """Wait for an entity to exist in the state machine.
+
+        Args:
+            session: Configured requests session
+            entity_id: Full entity ID to check
+            max_retries: Maximum number of retries (default 20 = 10 seconds total)
+            delay: Delay between retries in seconds
+
+        Returns:
+            True if entity exists, False otherwise
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        for attempt in range(max_retries):
+            # On first attempt, list all automation entities for debugging
+            if attempt == 0:
+                all_automations = self._list_automation_entities(session)
+                logger.debug(f"All automation entities in state machine: {all_automations}")
+
+            resp = self._get_entity_state(session, entity_id)
+            logger.debug(
+                f"Entity check attempt {attempt + 1}/{max_retries} for {entity_id}: "
+                f"status={resp.status_code}"
+            )
+            if resp.status_code == 200:
+                logger.debug(f"Entity {entity_id} found: {resp.json()}")
+                return True
+            await asyncio.sleep(delay)
+        return False
+
+    async def _subscribe_and_wait_for_update(self, websocket, msg_id, trigger_func, timeout=30):
+        """Subscribe to updates and wait for an update event after triggering an action.
+
+        This method:
+        1. Subscribes to automation_suggestions/subscribe
+        2. Waits for the subscription result
+        3. Waits for the initial event
+        4. Calls the trigger function (e.g., analyze_now)
+        5. Waits for the next event (from coordinator update)
+
+        Args:
+            websocket: Authenticated WebSocket connection
+            msg_id: Message ID to use for subscription
+            trigger_func: Callable that triggers the action (e.g., analyze_now)
+            timeout: Total timeout in seconds
+
+        Returns:
+            The event data from the update event containing stale_automations
+        """
+        import logging
+
+        logger = logging.getLogger(__name__)
+
+        # Step 1: Subscribe
+        subscribe_cmd = {
+            "id": msg_id,
+            "type": "automation_suggestions/subscribe",
+        }
+        await websocket.send(json.dumps(subscribe_cmd))
+        logger.debug(f"Sent subscribe command with id={msg_id}")
+
+        # Step 2: Wait for subscription result
+        message = await asyncio.wait_for(websocket.recv(), timeout=timeout)
+        data = json.loads(message)
+        logger.debug(
+            f"Received message after subscribe: type={data.get('type')}, id={data.get('id')}"
+        )
+
+        assert data["id"] == msg_id, f"Expected id={msg_id}, got {data['id']}"
+        assert data["type"] == "result", f"Expected result type, got: {data['type']}"
+        assert data["success"] is True, f"Subscribe failed: {data}"
+
+        # Step 3: Wait for initial event
+        message = await asyncio.wait_for(websocket.recv(), timeout=timeout)
+        initial_event = json.loads(message)
+        logger.debug(
+            f"Received initial event: type={initial_event.get('type')}, "
+            f"stale_total={initial_event.get('event', {}).get('stale_total')}"
+        )
+
+        assert initial_event["id"] == msg_id
+        assert initial_event["type"] == "event"
+        initial_stale_ids = [
+            s["automation_id"] for s in initial_event["event"].get("stale_automations", [])
+        ]
+        logger.debug(f"Initial stale automation IDs: {initial_stale_ids}")
+
+        # Step 4: Trigger the action (e.g., analyze_now)
+        logger.debug("Calling trigger function...")
+        trigger_func()
+
+        # Step 5: Wait for update event (skip events for other subscription IDs)
+        logger.debug("Waiting for update event from coordinator...")
+        while True:
+            message = await asyncio.wait_for(websocket.recv(), timeout=timeout)
+            update_event = json.loads(message)
+            logger.debug(
+                f"Received event: id={update_event.get('id')}, type={update_event.get('type')}, "
+                f"stale_total={update_event.get('event', {}).get('stale_total')}"
+            )
+
+            # Skip events from other subscriptions
+            if update_event.get("id") != msg_id:
+                logger.debug(f"Skipping event for id={update_event.get('id')}, waiting for id={msg_id}")
+                continue
+
+            assert update_event["type"] == "event"
+            break
+
+        updated_stale_ids = [
+            s["automation_id"] for s in update_event["event"].get("stale_automations", [])
+        ]
+        logger.debug(f"Updated stale automation IDs: {updated_stale_ids}")
+
+        return update_event["event"]
+
+    @pytest.mark.asyncio
+    async def test_triggered_automation_not_in_stale_list(
+        self, ha_url, ha_token, ha_session, authenticated_websocket
+    ):
+        """Test that a recently triggered automation is NOT in the stale list.
+
+        This test:
+        1. Creates two test automations
+        2. Verifies the automations exist in the state machine
+        3. Triggers one of them (giving it a recent last_triggered)
+        4. Subscribes to updates and triggers analysis
+        5. Waits for the update event (not time-based)
+        6. Verifies the triggered automation is NOT stale
+        7. Verifies the non-triggered automation IS stale (never triggered = 999 days)
+        """
+        import logging
+        import time
+
+        logger = logging.getLogger(__name__)
+
+        websocket = authenticated_websocket
+        session = ha_session
+
+        # Generate unique IDs for this test run
+        test_id = int(time.time())
+        triggered_id = f"e2e_test_triggered_{test_id}"
+        not_triggered_id = f"e2e_test_not_triggered_{test_id}"
+        triggered_entity = f"automation.{triggered_id}"
+        not_triggered_entity = f"automation.{not_triggered_id}"
+
+        try:
+            # Step 1: Create two test automations
+            logger.debug(f"Creating automation: {triggered_id}")
+            resp1 = self._create_automation(session, triggered_id, f"E2E Test Triggered {test_id}")
+            logger.debug(
+                f"Create triggered automation response: status={resp1.status_code}, body={resp1.text}"
+            )
+            assert resp1.status_code in (
+                200,
+                201,
+            ), f"Failed to create triggered automation: {resp1.text}"
+
+            logger.debug(f"Creating automation: {not_triggered_id}")
+            resp2 = self._create_automation(
+                session, not_triggered_id, f"E2E Test Not Triggered {test_id}"
+            )
+            logger.debug(
+                f"Create not-triggered automation response: status={resp2.status_code}, body={resp2.text}"
+            )
+            assert resp2.status_code in (
+                200,
+                201,
+            ), f"Failed to create non-triggered automation: {resp2.text}"
+
+            # Reload automations to register them in the state machine
+            logger.debug("Reloading automations...")
+            reload_resp = self._reload_automations(session)
+            logger.debug(f"Reload response: status={reload_resp.status_code}")
+            assert reload_resp.status_code in (
+                200,
+                201,
+            ), f"Failed to reload automations: {reload_resp.text}"
+
+            # Step 2: Verify automations exist in the state machine
+            logger.debug(f"Waiting for {triggered_entity} to exist...")
+            triggered_exists = await self._wait_for_entity(session, triggered_entity)
+            assert (
+                triggered_exists
+            ), f"Automation {triggered_entity} was not created in state machine"
+
+            logger.debug(f"Waiting for {not_triggered_entity} to exist...")
+            not_triggered_exists = await self._wait_for_entity(session, not_triggered_entity)
+            assert (
+                not_triggered_exists
+            ), f"Automation {not_triggered_entity} was not created in state machine"
+
+            # Step 3: Trigger one automation to give it a recent last_triggered
+            logger.debug(f"Triggering automation: {triggered_entity}")
+            trigger_resp = self._trigger_automation(session, triggered_entity)
+            logger.debug(
+                f"Trigger response: status={trigger_resp.status_code}, body={trigger_resp.text}"
+            )
+            assert trigger_resp.status_code in (
+                200,
+                201,
+            ), f"Failed to trigger automation: {trigger_resp.text}"
+
+            # Brief wait for trigger to be processed
+            await asyncio.sleep(2)
+
+            # DEBUG: Check the automation state after triggering
+            state_resp = self._get_entity_state(session, triggered_entity)
+            if state_resp.status_code == 200:
+                state_data = state_resp.json()
+                attrs = state_data.get("attributes", {})
+                last_triggered = attrs.get("last_triggered")
+                logger.debug(
+                    f"DEBUG: After trigger - {triggered_entity} last_triggered={last_triggered}, "
+                    f"state={state_data.get('state')}, all_attrs={attrs}"
+                )
+            else:
+                logger.debug(f"DEBUG: Failed to get state of {triggered_entity}: {state_resp.status_code}")
+
+            # Step 4 & 5: Subscribe to updates and wait for analysis to complete
+            logger.debug("Subscribing and triggering analysis...")
+
+            # DEBUG: Verify state is still correct right before analysis
+            state_check = self._get_entity_state(session, triggered_entity)
+            if state_check.status_code == 200:
+                state_data = state_check.json()
+                lt = state_data.get("attributes", {}).get("last_triggered")
+                logger.debug(f"DEBUG: Pre-analysis state check - {triggered_entity} last_triggered={lt}")
+
+            def trigger_analysis():
+                analysis_resp = self._trigger_analysis(session)
+                logger.debug(f"Analysis trigger response: status={analysis_resp.status_code}")
+                assert analysis_resp.status_code in (
+                    200,
+                    201,
+                ), f"Failed to trigger analysis: {analysis_resp.text}"
+
+            event_data = await self._subscribe_and_wait_for_update(
+                websocket, msg_id=1, trigger_func=trigger_analysis, timeout=30
+            )
+
+            # Step 6 & 7: Verify results from the update event
+            stale_automations = event_data.get("stale_automations", [])
+            stale_ids = [s["automation_id"] for s in stale_automations]
+            logger.debug(f"Final stale automation IDs: {stale_ids}")
+
+            # DEBUG: Log full stale automation data to understand why triggered is being included
+            for stale_auto in stale_automations:
+                logger.debug(
+                    f"DEBUG Stale: {stale_auto['automation_id']} - "
+                    f"days_since_triggered={stale_auto.get('days_since_triggered')}, "
+                    f"last_triggered={stale_auto.get('last_triggered')}"
+                )
+
+            # The triggered automation should NOT be in the stale list
+            # (it was just triggered, so last_triggered is recent)
+            assert triggered_entity not in stale_ids, (
+                f"Recently triggered automation {triggered_entity} should NOT be stale. "
+                f"Stale list contains: {stale_ids}"
+            )
+
+            # The non-triggered automation SHOULD be in the stale list
+            # (never triggered = 999 days since trigger > 30 day threshold)
+            assert not_triggered_entity in stale_ids, (
+                f"Never-triggered automation {not_triggered_entity} should be stale. "
+                f"Stale list contains: {stale_ids}"
+            )
+
+            # Verify the stale automation has correct properties
+            not_triggered_stale = next(
+                (s for s in stale_automations if s["automation_id"] == not_triggered_entity),
+                None,
+            )
+            assert not_triggered_stale is not None
+            # Never triggered should have 999 days or very high value
+            assert not_triggered_stale["days_since_triggered"] >= 30, (
+                f"Never-triggered automation should have days_since_triggered >= 30, "
+                f"got {not_triggered_stale['days_since_triggered']}"
+            )
+
+        finally:
+            # Cleanup: Delete test automations
+            logger.debug(f"Cleaning up: deleting {triggered_id} and {not_triggered_id}")
+            self._delete_automation(session, triggered_id)
+            self._delete_automation(session, not_triggered_id)
+            # Reload automations to remove deleted entities from state machine
+            self._reload_automations(session)
+
+    @pytest.mark.asyncio
+    async def test_stale_detection_counts_match(
+        self, ha_url, ha_token, ha_session, authenticated_websocket
+    ):
+        """Test that stale automation total count is accurate after triggering.
+
+        This test verifies that the total count in the stale list response
+        accurately reflects the number of stale automations.
+        """
+        import logging
+        import time
+
+        logger = logging.getLogger(__name__)
+
+        websocket = authenticated_websocket
+        session = ha_session
+
+        # DEBUG: Log ALL automation entities at start of test
+        all_automations = self._list_automation_entities(session)
+        logger.info(f"DEBUG: All automation entities at test start: {all_automations}")
+
+        # Subscribe and wait for initial analysis to establish baseline
+        # (This ensures we wait for the coordinator update, not just fire-and-forget)
+        logger.debug("Subscribing and triggering initial analysis for baseline...")
+
+        def trigger_initial_analysis():
+            analysis_resp = self._trigger_analysis(session)
+            logger.debug(f"Initial analysis trigger response: status={analysis_resp.status_code}")
+            assert analysis_resp.status_code in (
+                200,
+                201,
+            ), f"Failed to trigger initial analysis: {analysis_resp.text}"
+
+        baseline_event = await self._subscribe_and_wait_for_update(
+            websocket, msg_id=1, trigger_func=trigger_initial_analysis, timeout=30
+        )
+
+        initial_total = baseline_event.get("stale_total", 0)
+        initial_stale_ids = [s["automation_id"] for s in baseline_event.get("stale_automations", [])]
+        logger.info(f"Initial stale count: {initial_total}, IDs: {initial_stale_ids}")
+
+        # DEBUG: Log details of each stale automation
+        for stale in baseline_event.get("stale_automations", []):
+            logger.info(f"DEBUG Baseline stale: {stale['automation_id']} - days_since={stale.get('days_since_triggered')}")
+
+        # Create a new automation (never triggered = stale)
+        test_id = int(time.time())
+        test_automation_id = f"e2e_test_count_{test_id}"
+        test_entity = f"automation.{test_automation_id}"
+
+        try:
+            logger.debug(f"Creating automation: {test_automation_id}")
+            resp = self._create_automation(session, test_automation_id, f"E2E Test Count {test_id}")
+            logger.debug(f"Create automation response: status={resp.status_code}, body={resp.text}")
+            assert resp.status_code in (200, 201), f"Failed to create automation: {resp.text}"
+
+            # Reload automations to register them in the state machine
+            logger.debug("Reloading automations...")
+            reload_resp = self._reload_automations(session)
+            logger.debug(f"Reload response: status={reload_resp.status_code}")
+            assert reload_resp.status_code in (
+                200,
+                201,
+            ), f"Failed to reload automations: {reload_resp.text}"
+
+            # Wait for entity to exist in state machine
+            logger.debug(f"Waiting for {test_entity} to exist...")
+            entity_exists = await self._wait_for_entity(session, test_entity)
+            assert entity_exists, f"Automation {test_entity} was not created in state machine"
+
+            # Subscribe and trigger analysis, wait for update event
+            logger.debug("Subscribing and triggering analysis...")
+
+            def trigger_analysis():
+                analysis_resp = self._trigger_analysis(session)
+                logger.debug(f"Analysis trigger response: status={analysis_resp.status_code}")
+                assert analysis_resp.status_code in (
+                    200,
+                    201,
+                ), f"Failed to trigger analysis: {analysis_resp.text}"
+
+            event_data = await self._subscribe_and_wait_for_update(
+                websocket, msg_id=2, trigger_func=trigger_analysis, timeout=30
+            )
+
+            # Get results from the update event
+            new_stale_automations = event_data.get("stale_automations", [])
+            new_total = event_data.get("stale_total", 0)
+            new_stale_ids = [s["automation_id"] for s in new_stale_automations]
+            logger.info(f"New stale count: {new_total}, IDs: {new_stale_ids}")
+
+            # The new automation should be in the stale list
+            assert test_entity in new_stale_ids, (
+                f"New automation {test_entity} should be in stale list. "
+                f"Stale list: {new_stale_ids}"
+            )
+
+            # Total should have increased by 1
+            assert new_total == initial_total + 1, (
+                f"Total should increase from {initial_total} to {initial_total + 1}, "
+                f"but got {new_total}"
+            )
+
+            # List length should match total
+            assert len(new_stale_automations) == new_total, (
+                f"Stale list length {len(new_stale_automations)} " f"should match total {new_total}"
+            )
+
+        finally:
+            # Cleanup
+            logger.debug(f"Cleaning up: deleting {test_automation_id}")
+            self._delete_automation(session, test_automation_id)
+            # Reload automations to remove deleted entities from state machine
+            self._reload_automations(session)

--- a/tests/e2e/visual_test_stale_automations.md
+++ b/tests/e2e/visual_test_stale_automations.md
@@ -1,0 +1,518 @@
+# Visual E2E Tests: Stale Automation Detection
+
+This document defines visual E2E tests for the stale automation detection feature's Lovelace card interface. These tests are designed to be run interactively using Claude Chrome MCP browser automation tools.
+
+## Prerequisites
+
+### 1. Start the Test Environment
+
+Start the Home Assistant Docker container with the custom component installed:
+
+```bash
+cd /Users/dan/dev/homeassist/ha-dashboard-2026-public
+python tests/e2e/start_visual_test.py
+```
+
+This will output the URL (e.g., `http://localhost:32768`). Note this URL for the tests.
+
+### 2. Complete Home Assistant Onboarding
+
+If this is a fresh container, complete onboarding:
+- Create account: username `test`, password `test`
+- Skip integrations setup
+
+### 3. Configure the Automation Suggestions Integration
+
+1. Navigate to **Settings > Devices & Services**
+2. Click **Add Integration**
+3. Search for "Automation Suggestions"
+4. Complete the configuration with default values
+
+### 4. Add the Card Resource
+
+1. Navigate to **Settings > Dashboards > Resources** (or three-dot menu > Resources)
+2. Click **Add Resource**
+3. URL: `/local/custom_components/automation_suggestions/www/automation-suggestions-card.js`
+4. Resource type: JavaScript module
+
+### 5. Create a Dashboard with the Card
+
+1. Navigate to **Overview** dashboard
+2. Click three-dot menu > **Edit Dashboard** > **Take Control**
+3. Click **Add Card**
+4. Select "Custom: Automation Suggestions" or use YAML:
+   ```yaml
+   type: custom:automation-suggestions-card
+   ```
+
+### 6. Create Test Automations
+
+To test stale automation detection, create several test automations with varying states:
+
+#### Active Automation (triggered recently)
+```yaml
+alias: Test Active Automation
+trigger:
+  - platform: time
+    at: "00:00:00"
+action:
+  - service: logger.log
+    data:
+      message: "Test"
+mode: single
+```
+
+#### Stale Automation (never triggered)
+```yaml
+alias: Test Stale Never Triggered
+trigger:
+  - platform: event
+    event_type: nonexistent_event
+action:
+  - service: logger.log
+    data:
+      message: "Never runs"
+mode: single
+```
+
+#### Disabled Automation
+Create an automation and disable it via the UI or:
+```yaml
+alias: Test Disabled Automation
+trigger:
+  - platform: time
+    at: "23:59:59"
+action:
+  - service: logger.log
+    data:
+      message: "Disabled"
+mode: single
+```
+Then disable it via **Settings > Automations & Scenes**, find the automation, and toggle off.
+
+---
+
+## Test Cases
+
+### Test 1: Card Loads with Tabs Visible
+
+**Objective:** Verify the card renders with both "Suggestions" and "Stale" tabs.
+
+**Preconditions:**
+- Card is added to dashboard
+- Integration is configured
+
+**Steps:**
+
+1. Navigate to the dashboard containing the automation-suggestions-card
+   ```
+   Chrome MCP: mcp__claude-in-chrome__navigate
+   URL: http://localhost:<port>/lovelace/0
+   ```
+
+2. Wait for page to load (2-3 seconds)
+
+3. Take a screenshot to capture card state
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: screenshot
+   ```
+
+4. Read the page to find tab elements
+   ```
+   Chrome MCP: mcp__claude-in-chrome__read_page
+   ```
+
+**Expected Results:**
+- Card displays with header "Automation Suggestions"
+- Two tab buttons are visible: "Suggestions (N)" and "Stale (N)"
+- "Suggestions" tab is active by default (highlighted with primary color border)
+- Both tabs show count badges in parentheses
+- Card content area shows suggestions list or empty state
+
+**Verification Queries:**
+- Look for elements with class `tab-btn`
+- Verify `tab-btn.active` exists and contains "Suggestions"
+- Verify both tabs display count numbers
+
+---
+
+### Test 2: Clicking Stale Tab Shows Stale Automations List
+
+**Objective:** Verify clicking the "Stale" tab switches content to show stale automations.
+
+**Preconditions:**
+- Card is loaded on dashboard
+- At least one stale automation exists (either never triggered or not triggered within threshold)
+
+**Steps:**
+
+1. Navigate to dashboard if not already there
+   ```
+   Chrome MCP: mcp__claude-in-chrome__navigate
+   URL: http://localhost:<port>/lovelace/0
+   ```
+
+2. Click the "Stale" tab
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: click
+   coordinate: [x, y] (center of Stale tab button)
+   ```
+
+   Alternative using find:
+   ```
+   Chrome MCP: mcp__claude-in-chrome__find
+   query: "Stale"
+   action: click
+   ```
+
+3. Take a screenshot
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: screenshot
+   ```
+
+4. Read the page content
+   ```
+   Chrome MCP: mcp__claude-in-chrome__read_page
+   ```
+
+**Expected Results:**
+- "Stale" tab becomes active (highlighted)
+- "Suggestions" tab becomes inactive
+- Content area displays list of stale automations
+- Each stale automation shows:
+  - Automation name
+  - Last triggered date or "Never"
+  - Days since triggered
+
+**Verification Queries:**
+- Verify `tab-btn.active` now contains "Stale"
+- Look for `.stale-item` elements in the DOM
+- Verify automation names are displayed
+
+---
+
+### Test 3: Stale Automation Displays Name, Last Triggered Date, and Days Since
+
+**Objective:** Verify each stale automation item shows correct details.
+
+**Preconditions:**
+- Stale tab is active
+- At least one stale automation exists
+
+**Steps:**
+
+1. Ensure on Stale tab (repeat Test 2 steps if needed)
+
+2. Read page to examine stale item structure
+   ```
+   Chrome MCP: mcp__claude-in-chrome__read_page
+   ```
+
+3. Take a detailed screenshot
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: screenshot
+   ```
+
+**Expected Results:**
+For each stale automation item (`.stale-item`):
+- `.stale-name` contains the automation's friendly name
+- `.stale-meta` shows "Last triggered: [date] ([N] days ago)" format
+- If automation never triggered: "Last triggered: Never (Never triggered)"
+- Layout: name on first line, metadata on second line, dismiss button on right
+
+**Sample Expected HTML Structure:**
+```html
+<div class="stale-item">
+  <div class="stale-main">
+    <span class="stale-name">Test Stale Never Triggered</span>
+  </div>
+  <div class="stale-meta">
+    Last triggered: Never (Never triggered)
+  </div>
+  <button class="dismiss-btn" data-suggestion-id="automation.test_stale_never_triggered">
+    <ha-icon icon="mdi:close"></ha-icon>
+  </button>
+</div>
+```
+
+---
+
+### Test 4: Disabled Automations Show Disabled Badge
+
+**Objective:** Verify disabled automations display a "Disabled" badge.
+
+**Preconditions:**
+- Stale tab is active
+- At least one disabled automation exists that is also stale
+
+**Steps:**
+
+1. Ensure Stale tab is active
+
+2. Read page to find disabled badge
+   ```
+   Chrome MCP: mcp__claude-in-chrome__read_page
+   ```
+
+3. Take screenshot capturing the disabled badge
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: screenshot
+   ```
+
+**Expected Results:**
+- Disabled stale automations have an orange badge with text "DISABLED"
+- Badge appears next to the automation name in `.stale-main`
+- Badge uses class `badge disabled`
+- Badge styling: orange background (`--warning-color`), white text, uppercase
+
+**Sample Expected HTML:**
+```html
+<div class="stale-main">
+  <span class="stale-name">Test Disabled Automation</span>
+  <span class="badge disabled">Disabled</span>
+</div>
+```
+
+---
+
+### Test 5: Dismiss Button Removes Automation from List
+
+**Objective:** Verify clicking the dismiss button removes the automation from the stale list.
+
+**Preconditions:**
+- Stale tab is active
+- At least one stale automation is displayed
+
+**Steps:**
+
+1. Note the current count in the Stale tab badge
+   ```
+   Chrome MCP: mcp__claude-in-chrome__read_page
+   ```
+
+2. Find and note the first stale automation's name
+
+3. Click the dismiss button (X icon) for the first automation
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: click
+   coordinate: [x, y] (center of dismiss button)
+   ```
+
+   Alternative approach - use JavaScript:
+   ```
+   Chrome MCP: mcp__claude-in-chrome__javascript_tool
+   script: document.querySelector('.stale-item .dismiss-btn').click()
+   ```
+
+4. Wait for WebSocket update (500ms)
+
+5. Take a screenshot
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: screenshot
+   ```
+
+6. Read page to verify removal
+   ```
+   Chrome MCP: mcp__claude-in-chrome__read_page
+   ```
+
+**Expected Results:**
+- Dismissed automation no longer appears in the list
+- Stale tab badge count decreases by 1
+- Other stale automations remain visible
+- No error messages displayed
+
+---
+
+### Test 6: Empty State Displays Correctly When No Stale Automations
+
+**Objective:** Verify the empty state message when all stale automations are dismissed or none exist.
+
+**Preconditions:**
+- Stale tab is active
+- No stale automations exist (or all have been dismissed)
+
+**Steps:**
+
+1. If stale automations exist, dismiss all of them (repeat Test 5)
+
+2. Once list is empty, take screenshot
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: screenshot
+   ```
+
+3. Read page content
+   ```
+   Chrome MCP: mcp__claude-in-chrome__read_page
+   ```
+
+**Expected Results:**
+- Content area shows centered empty state
+- Checkmark icon (`mdi:check-circle`) is displayed
+- Primary text: "No stale automations found."
+- Secondary hint text: "All your automations have triggered within the threshold."
+- Stale tab badge shows "(0)"
+
+**Sample Expected HTML:**
+```html
+<div class="card-content empty">
+  <ha-icon icon="mdi:check-circle"></ha-icon>
+  <span>No stale automations found.</span>
+  <span class="empty-hint">All your automations have triggered within the threshold.</span>
+</div>
+```
+
+---
+
+### Test 7: Tab Switching Works Correctly Between Suggestions and Stale
+
+**Objective:** Verify smooth tab switching in both directions without content corruption.
+
+**Preconditions:**
+- Card is loaded with some suggestions and/or stale automations
+
+**Steps:**
+
+1. Start on Suggestions tab (default)
+
+2. Take initial screenshot
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: screenshot
+   ```
+
+3. Click Stale tab
+   ```
+   Chrome MCP: mcp__claude-in-chrome__find
+   query: "Stale"
+   action: click
+   ```
+
+4. Take screenshot of Stale tab
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: screenshot
+   ```
+
+5. Click Suggestions tab
+   ```
+   Chrome MCP: mcp__claude-in-chrome__find
+   query: "Suggestions"
+   action: click
+   ```
+
+6. Take screenshot showing return to Suggestions
+   ```
+   Chrome MCP: mcp__claude-in-chrome__computer
+   action: screenshot
+   ```
+
+7. Rapidly switch tabs 3 times
+   ```
+   Chrome MCP: mcp__claude-in-chrome__javascript_tool
+   script: |
+     const tabs = document.querySelectorAll('.tab-btn');
+     for (let i = 0; i < 3; i++) {
+       setTimeout(() => tabs[1].click(), i * 200);
+       setTimeout(() => tabs[0].click(), i * 200 + 100);
+     }
+   ```
+
+8. Wait 1 second, take final screenshot
+
+**Expected Results:**
+- Tab switching is immediate (no loading indicators)
+- Active tab styling updates correctly each switch
+- Content area updates to match selected tab
+- No content "flashing" or corruption during rapid switches
+- Scan Now button remains visible in card actions regardless of tab
+- Tab counts remain accurate after switching
+
+---
+
+## Additional Verification Points
+
+### CSS Styling Verification
+
+Use these JavaScript queries to verify styling is applied correctly:
+
+```javascript
+// Check tab styling
+const activeTab = document.querySelector('.tab-btn.active');
+const computedStyle = getComputedStyle(activeTab);
+console.log('Border color:', computedStyle.borderBottomColor); // Should be primary-color
+
+// Check stale item layout
+const staleItem = document.querySelector('.stale-item');
+if (staleItem) {
+  const gridStyle = getComputedStyle(staleItem);
+  console.log('Grid template:', gridStyle.gridTemplateColumns); // Should be "1fr auto"
+}
+
+// Check badge styling
+const badge = document.querySelector('.badge.disabled');
+if (badge) {
+  const badgeStyle = getComputedStyle(badge);
+  console.log('Badge background:', badgeStyle.backgroundColor); // Should be warning-color
+}
+```
+
+### WebSocket Subscription Verification
+
+Verify the WebSocket connection is active:
+
+```javascript
+// In browser console
+console.log('Suggestions:', document.querySelector('automation-suggestions-card')._suggestions);
+console.log('Stale:', document.querySelector('automation-suggestions-card')._staleAutomations);
+console.log('Active tab:', document.querySelector('automation-suggestions-card')._activeTab);
+```
+
+---
+
+## Troubleshooting
+
+### Card Not Loading
+
+1. Check browser console for errors
+2. Verify resource is registered correctly
+3. Ensure integration is configured
+4. Check WebSocket connection in Network tab
+
+### Stale Tab Shows 0 When Automations Exist
+
+1. Verify automations are truly stale (check `last_triggered` attribute in Developer Tools > States)
+2. Check stale threshold setting in integration options
+3. Verify automations are not in ignore patterns
+
+### Dismiss Not Working
+
+1. Check browser console for service call errors
+2. Verify `automation_suggestions.dismiss` service is registered
+3. Check that `data-suggestion-id` attribute is set correctly
+
+---
+
+## Test Data Reset
+
+To reset test data between test runs:
+
+1. Stop the container (press Enter in start_visual_test.py terminal)
+2. Restart with `python tests/e2e/start_visual_test.py`
+3. Repeat prerequisites setup
+
+Or to clear dismissed items without restart:
+
+```javascript
+// Clear storage (requires HA restart to take effect)
+// Via Developer Tools > Services:
+// Service: automation_suggestions.analyze_now
+```


### PR DESCRIPTION
## Summary

- Adds stale automation detection feature that identifies automations that haven't triggered in 30+ days
- Includes tabbed UI in the Lovelace card to view both suggestions and stale automations
- Provides WebSocket API for listing stale automations with pagination
- Fixes E2E test failures related to datetime handling and test coordination

## Features

- **Never triggered detection**: Identifies automations that have never run (999+ days)
- **Long inactive detection**: Finds automations inactive for 30+ days (configurable)
- **Disabled automation marking**: Clearly shows which stale automations are disabled
- **UI integration**: New "Stale Automations" tab in the Lovelace card
- **Dismiss functionality**: Hide automations you intentionally keep inactive

## Technical Changes

- Fixed datetime handling in `find_stale_automations()` to support both datetime objects and strings
- Updated E2E tests to use subscribe-and-wait pattern for reliable coordinator updates
- Added comprehensive documentation with UI mockup

## Test Plan

- [x] All 274 unit/integration tests pass
- [x] All 9 E2E stale automation tests pass
- [x] Linting passes

## Screenshots

See README.md for UI mockup showing the new tabbed interface.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)